### PR TITLE
Fix for selection=exclusive

### DIFF
--- a/plugin/speeddating.vim
+++ b/plugin/speeddating.vim
@@ -171,6 +171,9 @@ function! s:incrementvisual(count)
     let ve = &ve
     set virtualedit=all
     exe "norm! gv\<Esc>"
+    if &selection ==# 'exclusive' && getpos('.') == getpos("'>")
+        normal! h
+    endif
     let vcol = virtcol('.')
     let lnum = line("'<")
     let lastrepl = ""


### PR DESCRIPTION
To reproduce:

```
:set selection=exclusive
:call setline(1, '2010-10-10 i am here')
:execute "normal vE\<C-a>"
```

Expected: `2010-10-11 i am here`
Actual:   `2010-10-10 ii am here`
