### PR TITLE
Fix first column increment in visual mode

### DIFF
--- a/plugin/speeddating.vim
+++ b/plugin/speeddating.vim
@@ -186,7 +186,7 @@ function! s:incrementvisual(count)
             let end = s:setvirtcol(lnum,virtcol('.'))
             call s:setvirtcol(lnum,vcol)
             if strpart(getline('.'),start,end-start) =~ '^\s*$'
-                let before_padded = printf("%-".start."s",strpart(getline('.'),0,start))
+                let before_padded = start == end ? '' : printf("%-".start."s",strpart(getline('.'),0,start))
                 let tweaked_line  = before_padded.strpart(lastrepl,laststart,lastend-laststart).strpart(getline('.'),end)
                 let [repl,offset,start,end] = s:incrementstring(tweaked_line,col('.')-1,a:count*(lnum-lastlnum))
             endif


### PR DESCRIPTION
How to reproduce:

```
:call setline(1, ['0', '', ''])
:execute "normal VG\<C-a>"
```

Expected:

```
1
2
3
```

Actual:

```
1
 2
 3
```
