### PR TITLE
Fix localtime() in neovim

### DIFF
--- a/autoload/speeddating.vim
+++ b/autoload/speeddating.vim
@@ -461,7 +461,7 @@ function! s:strftime(pattern,time)
 endfunction
 
 function! s:localtime(...)
-  let ts = a:0 ? a:1 : has('unix') ? reltimestr(reltime()) : localtime().'.0'
+  let ts = a:0 ? a:1 : has('unix')&&!has('nvim') ? reltimestr(reltime()) : localtime().'.0'
   let us = matchstr(ts,'\.\zs.\{0,6\}')
   let us .= repeat(0,6-strlen(us))
   let us = +matchstr(us,'[1-9].*')


### PR DESCRIPTION
In neovim `reltime()` is based on the system uptime rather than the
epoch so it can't be used to get the local time. Use the same fallback
as is used for non-Unix systems instead. This means that %k won't
support milliseconds as added in d03fc1a, but at least larger units of
time should be correct.
