### PR TITLE
ENH: Allow integration of other incrementors via fallback mappings

### DIFF
--- a/autoload/speeddating.vim
+++ b/autoload/speeddating.vim
@@ -102,9 +102,9 @@ function! speeddating#increment(increment)
     endif
   endfor
   if a:increment > 0
-    exe "norm! ". a:increment."\<C-A>"
+    exe "norm ". a:increment."\<Plug>SpeeddatingFallbackIncrement"
   else
-    exe "norm! ".-a:increment."\<C-X>"
+    exe "norm ".-a:increment."\<Plug>SpeeddatingFallbackDecrement"
   endif
   silent! call repeat#set("\<Plug>SpeedDating" . (a:increment < 0 ? "Down" : "Up"),a:increment < 0 ? -a:increment : a:increment)
 endfunction

--- a/doc/speeddating.txt
+++ b/doc/speeddating.txt
@@ -61,6 +61,12 @@ d<C-X>                  Change the time under the cursor to the current local
 .                       If you want to use |.| to repeat a speeddating.vim
                         mapping, install repeat.vim.
 
+                                                *speeddating-fallback*
+To integrate with other incrementor scripts (such as swapit.vim or
+monday.vim), map <Plug>SpeeddatingFallbackIncrement and
+<Plug>SpeeddatingFallbackDecrement to the keys that should be invoked when
+the cursor is not on a date or time that this plugin can handle.
+
 FORMATS                                         *speeddating-formats*
 
 One can use the :SpeedDatingFormat command to list, add, and remove formats.

--- a/plugin/speeddating.vim
+++ b/plugin/speeddating.vim
@@ -47,6 +47,13 @@ vnoremap <silent> <Plug>SpeedDatingDown :<C-U>call speeddating#incrementvisual(-
 nnoremap <silent> <Plug>SpeedDatingNowLocal :<C-U>call speeddating#timestamp(0,v:count)<CR>
 nnoremap <silent> <Plug>SpeedDatingNowUTC   :<C-U>call speeddating#timestamp(1,v:count)<CR>
 
+if empty(maparg('<Plug>SpeeddatingFallbackIncrement', 'n'))
+    nnoremap <Plug>SpeeddatingFallbackIncrement <C-A>
+endif
+if empty(maparg('<Plug>SpeeddatingFallbackDecrement', 'n'))
+    nnoremap <Plug>SpeeddatingFallbackDecrement <C-X>
+endif
+
 if !exists("g:speeddating_no_mappings") || !g:speeddating_no_mappings
   nmap  <C-A>     <Plug>SpeedDatingUp
   nmap  <C-X>     <Plug>SpeedDatingDown


### PR DESCRIPTION
The same has been implemented for the [swapit.vim](https://github.com/mjbrownie/swapit) plugin. This allows users to chain together multiple incrementors: If speeddating doesn't recognize a valid date / time, it invokes `<Plug>SpeeddatingFallbackIncrement` instead of `<C-A>` directly.
