### PR TITLE
Introduce g:speeddating_fallback_mappings

### DIFF
--- a/plugin/speeddating.vim
+++ b/plugin/speeddating.vim
@@ -47,12 +47,16 @@ vnoremap <silent> <Plug>SpeedDatingDown :<C-U>call speeddating#incrementvisual(-
 nnoremap <silent> <Plug>SpeedDatingNowLocal :<C-U>call speeddating#timestamp(0,v:count)<CR>
 nnoremap <silent> <Plug>SpeedDatingNowUTC   :<C-U>call speeddating#timestamp(1,v:count)<CR>
 
-for [s:key, s:type] in [['<C-A>', 'Up'], ['<C-X>', 'Down']]
+if !exists("g:speeddating_fallback_mappings")
+  let g:speeddating_fallback_mappings = [['<C-A>', '<C-A>', 'Up'], ['<C-X>', '<C-X>', 'Down']]
+endif
+
+for [s:key, s:keyorg, s:type] in g:speeddating_fallback_mappings
   let s:rhs = maparg(s:key, 'n')
   if !empty(maparg('<Plug>SpeedDatingFallback'.s:type, 'n'))
     continue
   elseif s:rhs =~# '^$\|^<Plug>SpeedDating'
-    exe 'nnoremap <Plug>SpeedDatingFallback'.s:type s:key
+    exe 'nnoremap <Plug>SpeedDatingFallback'.s:type s:keyorg
   else
     exe 'nmap <Plug>SpeedDatingFallback'.s:type s:rhs
   endif


### PR DESCRIPTION
In mswin.vim ctrl-a is mapped to selecting all text.
If one therefore maps speeddatingup to something different (e.g. `<C-_>`) the above changes to adjust the fallback accordingly.
the corresponding settings in my _vimrc are as follows:
```
let g:speeddating_no_mappings=1
let g:speeddating_fallback_mappings = [['<C-_>', '<C-A>', 'Up'], ['<C-X>', '<C-X>', 'Down']]
nmap  <C-_>     <Plug>SpeedDatingUp
xmap  <C-_>     <Plug>SpeedDatingUp
nmap d<C-_>     <Plug>SpeedDatingNowUTC
nmap  <C-X>     <Plug>SpeedDatingDown
xmap  <C-X>     <Plug>SpeedDatingDown
nmap d<C-X>     <Plug>SpeedDatingNowLocal
```