### PR TITLE
Add g:speeddating_count_mappings.

### DIFF
--- a/autoload/speeddating.vim
+++ b/autoload/speeddating.vim
@@ -81,6 +81,19 @@ function! s:replaceinline(start,end,new)
   call setpos("']",[0,line('.'),a:start+strlen(a:new),0])
 endfunction
 
+" remap non-negative or empty count argument
+function! s:remapcount(count,mappings)
+  let l:count = count
+  let l:result = ''
+  while l:count > 0
+    let l:digit = l:count % 10
+    let l:mapped = a:mappings[l:digit]
+    let l:result = l:mapped . l:result
+    let l:count = l:count / 10
+  endwhile
+  return l:result
+endfunction
+
 " }}}1
 " Normal Mode {{{1
 
@@ -102,9 +115,19 @@ function! speeddating#increment(increment)
     endif
   endfor
   if a:increment > 0
-    exe "norm ". a:increment."\<Plug>SpeedDatingFallbackUp"
+    if exists('g:speeddating_count_mappings')
+      let l:count = s:remapcount(a:increment,g:speeddating_count_mappings)
+    else
+      let l:count = a:increment
+    endif
+    exe "norm ".l:count."\<Plug>SpeedDatingFallbackUp"
   else
-    exe "norm ".-a:increment."\<Plug>SpeedDatingFallbackDown"
+    if exists('g:speeddating_count_mappings')
+      let l:count = s:remapcount(-a:increment,g:speeddating_count_mappings)
+    else
+      let l:count = -a:increment
+    endif
+    exe "norm ".l:count."\<Plug>SpeedDatingFallbackDown"
   endif
   silent! call repeat#set("\<Plug>SpeedDating" . (a:increment < 0 ? "Down" : "Up"),a:increment < 0 ? -a:increment : a:increment)
 endfunction

--- a/doc/speeddating.txt
+++ b/doc/speeddating.txt
@@ -99,4 +99,14 @@ Beginning a format with a digit causes Vim to treat leading digits as a count
 instead.  To work around this escape it with %[] (e.g., %[2]0%0y%0m%0d%* is a
 decent format for DNS serials).
 
+This plugin assumes that your [count] mappings are input through your digit
+keys.  If this is not the case, you can set g:speeddating_count_mappings to a
+list of your mappings, starting from the mapping for 0 through to 9.  These
+mappings must be literal, e.g. if a count of zero is input with CTRL-B CTRL-A:
+>
+    let g:speeddating_count_mappings = [ "\<C-B>", ...]
+<
+(Hint: see `string` for an explanation of '\<...>' escapes, and `i_CTRL-V` to
+see how to insert special keys literally.)
+
  vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
Add a `g:speeddating_count_mappings` setting to allow the user to specify their command count mappings. This is aimed at #27.